### PR TITLE
Bump go to 1.22 and actions/setup-go to v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,9 @@ runs:
     #  env:
     #    NOTARY_DELEGATION_PASSPHRASE: "${{ inputs.private-key-passphrase }}"
     - name: Setup go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '^1.17'
+        go-version: '^1.22'
     - name: Setup the notary tool
       run: |
         go install -tags pkcs11 github.com/theupdateframework/notary/cmd/notary@latest


### PR DESCRIPTION
Bump go version to 1.22 and actions/setup-go version to v5 to avoid node 16 deprecation notice on GitHub actions builds.